### PR TITLE
Updated if's

### DIFF
--- a/configure
+++ b/configure
@@ -2,7 +2,7 @@
 
 CXX_STD=CXX17
 JTHREADS=4
-if [[ `uname` -eq Darwin ]] ; then
+if [[ `uname` == 'Darwin' ]] ; then
   CMAKE_BUILD_TYPE=Release
 fi
 if [[ $TRAVIS -eq true ]] ; then
@@ -57,7 +57,7 @@ echo "ITKURL;${itkgit}" >> ../data/softwareVersions.csv
 mkdir -p itkb
 cd itkb
 compflags=" -fPIC -O2 -Wno-c++11-long-long "
-if [[ `uname` -eq Darwin ]] ; then
+if [[ `uname` == 'Darwin' ]] ; then
     compflags=" ${compflags} -isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 -stdlib=libc++ "
 fi
 cmaker=`${R_HOME}/bin/Rscript -e "x=Sys.which('cmake'); cat(x)"`


### PR DESCRIPTION
The if statements where failing true under linux bash. Causing the configure to fail as the compiler does not understand the Mac compflags.
resolves #66 
